### PR TITLE
checking if syncerBin is executable and if tmpfsPath is writable (still not absolutly correct, but a beginning)

### DIFF
--- a/src/goanysync/goanysync/config.go
+++ b/src/goanysync/goanysync/config.go
@@ -9,6 +9,8 @@ import (
     "fmt"
     "goanysync/config"
     "strings"
+    "os/exec"
+    "os"
 )
 
 // configOptions to be read from the config file.
@@ -43,8 +45,28 @@ func ReadConfigFile(cfp string) (copts *ConfigOptions, err error) {
     //syncerBin, _ := c.String("DEFAULT", "RSYNC_BIN")
     //syncPaths, _ := c.String("DEFAULT", "WHATTOSYNC")
 
+    _, tmpfs_ok := c.Data["TMPFS"]
+    _, syncbin_ok := c.Data["RSYNC_BIN"]
+    _, paths_ok := c.Data["WHATTOSYNC"]
+
+    if ! tmpfs_ok {
+        err = errors.New("No TMPFS defined.")
+        return
+    }
     tmpfsPath := *c.Data["TMPFS"]
-    syncerBin := *c.Data["RSYNC_BIN"]
+
+    var syncerBin string = "rsync"
+    if ! syncbin_ok {
+        //err = errors.New("No RSYNC_BIN defined, assuming 'rsync'")
+        syncerBin = "rsync"
+    } else {
+        syncerBin = *c.Data["RSYNC_BIN"]
+    }
+
+    if ! paths_ok {
+        err = errors.New("No WHATTOSYNC defined.")
+        return
+    }
     syncPaths := *c.Data["WHATTOSYNC"]
 
     tmpfsPath = strings.TrimSpace(tmpfsPath)
@@ -53,20 +75,47 @@ func ReadConfigFile(cfp string) (copts *ConfigOptions, err error) {
 
     // Check that given options are valid to some degree
     if len(tmpfsPath) < 1 {
-        err = errors.New("Empty or no TMPFS path defined.")
+        err = errors.New("Empty TMPFS path defined.")
         return
     }
     if len(syncPaths) < 1 {
-        err = errors.New("Empty or no WHATTOSYNC paths defined.")
+        err = errors.New("Empty WHATTOSYNC paths defined.")
         return
     }
-    if len(syncerBin) < 1 {
-        // TODO: only do this if rsync can be found from PATH
-        syncerBin = "rsync"
+    // check if binary is inside path
+    sync_path, oerr := exec.LookPath(syncerBin)
+    if oerr != nil {
+        fmsg := fmt.Sprintf("Could not find the sync-binary. (%s) - %s", syncerBin, oerr)
+        err = errors.New(fmsg)
+        return
     }
-
-    // TODO: check that tmpfsPath is found and writable
-    // TODO: check that syncerBin is found and executable
+    // this only checks if _anyone_ can execute syncerBin -> TODO
+    file_stat, oerr := os.Stat(sync_path)
+    if oerr != nil {
+        fmsg := fmt.Sprintf("Could not execute stat() on sync-binary. (%s) - %s", syncerBin, oerr)
+        err = errors.New(fmsg)
+        return
+    }
+    syncerBin = sync_path
+    bin_perms := os.FileMode.Perm(file_stat.Mode())
+    if bin_perms & 0111 == 0 {
+        fmsg := fmt.Sprintf("The sync-binary is not executable. (%s)", syncerBin)
+        err = errors.New(fmsg)
+        return
+    }
+    // this again only checks if _anyone_ can write to tmpfsPath -> TODO
+    tmpfs_stat, oerr := os.Stat(tmpfsPath)
+    if oerr != nil {
+        fmsg := fmt.Sprintf("Could not execute stat() on tmpfsPath. (%s) - %s", tmpfsPath, oerr)
+        err = errors.New(fmsg)
+        return
+    }
+    tmpfs_perms := os.FileMode.Perm(tmpfs_stat.Mode())
+    if tmpfs_perms & 0222 == 0 {
+        fmsg := fmt.Sprintf("The tmpfsPath is not writable. (%s)", tmpfsPath)
+        err = errors.New(fmsg)
+        return
+    }
 
     // Parse WHATTOSYNC comma separated list of paths
     // XXX: if path names contain commas then though luck for now


### PR DESCRIPTION
- syncBinary has now a default value "rsync"
- syncBinary is searched inside PATH
- syncBinary is checked with filemode & 0111, means "can _anyone_ execute it"
- whattosync, tmpfs, and syncbinary are checked for existance (inside the config) before they get dereferenced - if they are not - it crashes during dereferencing 
- tmpfs is checked with filemode & 0222, means "can _anyone_ write it"

both filemode checks still have to be improved so that they check for the exactly needed permissions according to the user's uid and gid, but this is not so bad I think, because at this moment it is a root-only-application, means if anyone can execute/write it - root will be included...
